### PR TITLE
Fix except pattern typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A `forbid` pattern supports a few special cases:
 - `**`: Matches multiple path segments, including none.
 - `{variable}`: Matches a single path segment and captures it as a named variable.
 
-An `except` patterns supports the same special cases as `forbid`, and one more
+An `except` pattern supports the same special cases as `forbid`, and one more
 - `*`: Matches a single path segment.
 - `**`: Matches multiple path segments, including none.
 - `{variable}`: Matches this path segment when its value matches the one captured in the `forbid` pattern.


### PR DESCRIPTION
## Summary
- fix a typo in README

## Testing
- `go test ./...` *(fails: could not download go1.24.3 toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_684879a367048321b492b1f2f52723ec