### PR TITLE
Add Go 1.24 setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# AGENTS instructions
+
+To ensure this repository uses the correct Go toolchain during CI and for Codex,
+install Go 1.24 before running any builds or tests. Run the helper script
+`./scripts/setup-go-1.24.sh` which downloads Go 1.24.0 and installs it to
+`/usr/local/go`. The script also updates the PATH for the current session.

--- a/scripts/setup-go-1.24.sh
+++ b/scripts/setup-go-1.24.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GO_VERSION="1.24.0"
+GO_ARCH="linux-amd64"
+TARBALL="go${GO_VERSION}.${GO_ARCH}.tar.gz"
+
+if [ ! -f "$TARBALL" ]; then
+  echo "Downloading Go $GO_VERSION"
+  wget -q "https://go.dev/dl/${TARBALL}"
+fi
+
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf "$TARBALL"
+rm "$TARBALL"
+
+# Add Go to PATH for current session
+export PATH="/usr/local/go/bin:$PATH"
+
+echo "Go $GO_VERSION installed."


### PR DESCRIPTION
## Summary
- provide `AGENTS.md` with instructions for using Go 1.24
- add `scripts/setup-go-1.24.sh` helper script

## Testing
- `go test ./...` *(fails: Forbidden downloading Go toolchain)*
- `./scripts/setup-go-1.24.sh` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_b_68487b72ccf08321a32fb3c90774d9f3