### PR TITLE
Add Clean Architecture example

### DIFF
--- a/example/rules.yml
+++ b/example/rules.yml
@@ -46,3 +46,23 @@ specs:
       except:
       exempt:
         - "example/gamma/feature/B"
+
+  - name: clean architecture - domain independent
+    packages:
+      include:
+        - "example/zeta/domain/**"
+      exclude:
+    rules:
+      forbid:
+        - "**"
+      except:
+
+  - name: clean architecture - usecase without infrastructure
+    packages:
+      include:
+        - "example/zeta/usecase/**"
+      exclude:
+    rules:
+      forbid:
+        - "example/zeta/infrastructure/**"
+      except:

--- a/example/zeta/domain/entity.go
+++ b/example/zeta/domain/entity.go
@@ -1,0 +1,7 @@
+package domain
+
+import "github.com/TheFellow/arch-lint/example/zeta/usecase"
+
+type Entity struct {
+	Service usecase.Service
+}

--- a/example/zeta/infrastructure/db/repo.go
+++ b/example/zeta/infrastructure/db/repo.go
@@ -1,0 +1,3 @@
+package db
+
+type Repository struct{}

--- a/example/zeta/interfaces/controller.go
+++ b/example/zeta/interfaces/controller.go
@@ -1,0 +1,7 @@
+package interfaces
+
+import "github.com/TheFellow/arch-lint/example/zeta/usecase"
+
+type Controller struct {
+	Service usecase.Service
+}

--- a/example/zeta/usecase/service.go
+++ b/example/zeta/usecase/service.go
@@ -1,0 +1,7 @@
+package usecase
+
+import "github.com/TheFellow/arch-lint/example/zeta/infrastructure/db"
+
+type Service struct {
+	Repo db.Repository
+}

--- a/main_test.go
+++ b/main_test.go
@@ -29,4 +29,6 @@ func TestArchLint(t *testing.T) {
 var wantOut string = `
 arch-lint: [app package from api only] package "example/beta/bookstore/app/books" imports "example/beta/bookstore/app/authors"
 arch-lint: [app package from api or other features only] package "example/epsilon/bookstore/app/books/utils" imports "example/epsilon/bookstore/app/books"
+arch-lint: [clean architecture - domain independent] package "example/zeta/domain" imports "example/zeta/usecase"
+arch-lint: [clean architecture - usecase without infrastructure] package "example/zeta/usecase" imports "example/zeta/infrastructure/db"
 arch-lint: [no-experimental-imports] package "example/alpha" imports "example/alpha/experimental"`


### PR DESCRIPTION
## Summary
- extend `example/rules.yml` with Clean Architecture rules
- create new `zeta` example implementing domain/usecase/interfaces/infrastructure
- demonstrate rule violations in tests
- update test expectations
- tweak domain independence rule per review feedback

## Testing
- `go test ./...` *(fails: toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684879e7d9b08321aacec486fcd51b55